### PR TITLE
Hotfix 1.12.4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,13 @@ jobs:
         java-version: 1.8
         settings-path: ${{ github.workspace }}
 
+    - name: Load local Maven repository cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,8 +46,8 @@ jobs:
         settings-path: ${{ github.workspace }}
 
     - name: Load local Maven repository cache
-        uses: actions/cache@v2
-        with:
+      uses: actions/cache@v2
+      with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.12.3 (2021-12-16)
+1.12.4 (2021-12-16)
 -------------------
 
 **Added**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.12.3 (2021-12-16)
+-------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* org.apache.logging.log4j 2.15.0 -> 2.16.0 (addresses CVE-2021-45046)
+
+**Deprecated**
+
 1.12.3 (2021-11-13)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>projectwizard-portlet</artifactId>
-	<version>1.12.3</version>
+	<version>1.12.4</version>
 	<name>ProjectWizard Portlet</name>
-	<url>http://github.com/qbicsoftware/projectwizard-portlet</url>
+	<url>https://github.com/qbicsoftware/projectwizard-portlet</url>
 	<description>Creates hierarchical experiments using factorial design.</description>
 	<packaging>war</packaging>
 	<parent>
@@ -17,6 +17,7 @@
 	<properties>
 		<vaadin.version>7.7.28</vaadin.version>
 		<vaadin.plugin.version>7.7.28</vaadin.plugin.version>
+		<log4j.version>2.16.0</log4j.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -75,12 +76,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>life.qbic</groupId>


### PR DESCRIPTION
1.12.4 (2021-12-16)
-------------------

**Added**

**Fixed**

**Dependencies**

* org.apache.logging.log4j 2.15.0 -> 2.16.0 (addresses CVE-2021-45046)

**Deprecated**