### PR TITLE
Fix security issue with log4j

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.12.5 (2021-12-20)
+-------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* org.apache.logging.log4j 2.16.0 -> 2.17.0 (addresses CVE-2021-45105)
+
+**Deprecated**
+
 1.12.4 (2021-12-16)
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>projectwizard-portlet</artifactId>
-	<version>1.12.4</version>
+	<version>1.12.5</version>
 	<name>ProjectWizard Portlet</name>
 	<url>https://github.com/qbicsoftware/projectwizard-portlet</url>
 	<description>Creates hierarchical experiments using factorial design.</description>
@@ -17,7 +17,7 @@
 	<properties>
 		<vaadin.version>7.7.28</vaadin.version>
 		<vaadin.plugin.version>7.7.28</vaadin.plugin.version>
-		<log4j.version>2.16.0</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
1.12.5 (2021-12-20)
-------------------

**Added**

**Fixed**

**Dependencies**

* org.apache.logging.log4j 2.16.0 -> 2.17.0 (addresses CVE-2021-45105)

**Deprecated**
